### PR TITLE
remove logger.basicConfig from helper

### DIFF
--- a/wrapt_timeout_decorator/wrap_helper.py
+++ b/wrapt_timeout_decorator/wrap_helper.py
@@ -11,7 +11,6 @@ from typing import Any, Callable, Dict, List, Type, Union
 import dill             # type: ignore
 import multiprocess     # type: ignore
 
-logging.basicConfig()
 logger = logging.getLogger('pickle_analyzer')
 
 


### PR DESCRIPTION
One more problem found while trying to integrate the libary into an existing project.
When importing wrapt_timeout_decorator `logging.basicConfig()` gets called which prevents the application from setting up the root logger on its own. Shouldn't break anything. 