### PR TITLE
__init__: explicitly name exported functions for mypy --strict

### DIFF
--- a/wrapt_timeout_decorator/__init__.py
+++ b/wrapt_timeout_decorator/__init__.py
@@ -1,6 +1,6 @@
-from .wrapt_timeout_decorator import timeout
-from .wrap_helper import detect_unpickable_objects
-from .wrap_helper import detect_unpickable_objects_and_reraise
+from .wrapt_timeout_decorator import timeout as timeout
+from .wrap_helper import detect_unpickable_objects as detect_unpickable_objects
+from .wrap_helper import detect_unpickable_objects_and_reraise as detect_unpickable_objects_and_reraise
 
 # this needs to come after the module imports, otherwise circular import under windows
 from . import __init__conf__


### PR DESCRIPTION
This small PR fixes `mypy --strict` reporting `Module "wrapt_timeout_decorator" does not explicitly export attribute "timeout"` as per the explanation provided by https://github.com/tiangolo/typer/issues/112#issuecomment-648344361